### PR TITLE
inlet and outlet clock_sync no longer runs its own thread

### DIFF
--- a/tests/test_inlet.py
+++ b/tests/test_inlet.py
@@ -70,9 +70,9 @@ def test_inlet_collection():
     class LSLTestSystem(ez.Collection):
         SETTINGS = LSLTestSystemSettings
 
+        DUMMY = DummyOutlet()
         INLET = LSLInletUnit()
         LOGGER = DebugLog()
-        CLOCK = Clock()
         TERM = TerminateOnTotal()
 
         def configure(self) -> None:
@@ -84,13 +84,12 @@ def test_inlet_collection():
                 )
             )
             self.LOGGER.apply_settings(DebugLogSettings(name="test_inlet_collection"))
-            self.CLOCK.apply_settings(ClockSettings(dispatch_rate=20.0))
             self.TERM.apply_settings(TerminateOnTotalSettings(total=10))
 
         def network(self) -> ez.NetworkDefinition:
             return (
                 (self.INLET.OUTPUT_SIGNAL, self.LOGGER.INPUT),
-                (self.CLOCK.OUTPUT_CLOCK, self.TERM.INPUT_MESSAGE),
+                (self.LOGGER.OUTPUT, self.TERM.INPUT_MESSAGE),
             )
 
     # This next line raises an error if the ClockSync object runs its own thread.

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,16 +1,24 @@
 import time
 
 import numpy as np
+import pytest
 
 from ezmsg.lsl.util import ClockSync, collect_timestamp_pairs
 
 
-def test_clock_sync():
+@pytest.mark.parametrize("own_thread", [True, False])
+def test_clock_sync(own_thread: bool):
     tol = 10e-3  # 1 msec
 
-    clock_sync = ClockSync()
-    # Let it run a bit to get a stable estimate.
-    time.sleep(1.0)
+    clock_sync = ClockSync(run_thread=own_thread)
+    if own_thread:
+        # Let it run a bit to get a stable estimate.
+        time.sleep(1.0)
+        clock_sync.stop()
+    else:
+        for ix in range(10):
+            clock_sync.run_once()
+            time.sleep(0.1)
 
     offsets = []
     for _ in range(10):


### PR DESCRIPTION
The ClockSync object attached to an inlet or outlet no longer runs its own thread. Instead, the inlet(s) and/or outlet(s) will periodically (~0.1 sec) ask clock_sync to get an update. ClockSync internally rate-limits this updating even if there are multiple inlets and outlets sharing the same ClockSync object.