### PR TITLE
Do not block on first pull when timestamp processing enabled.

### DIFF
--- a/src/ezmsg/lsl/inlet.py
+++ b/src/ezmsg/lsl/inlet.py
@@ -254,6 +254,8 @@ class LSLInletProducer(BaseStatefulProducer[LSLInletSettings, typing.Optional[Ax
 
     def _setup_after_open(self) -> None:
         """Configure fetch buffer and message template after a stream is opened."""
+        # Re-thread the first-data warmup on every (re)connect.
+        self._warmed_up = False
         # Resolver is no longer needed once connected. Destroy it now (while we're
         # in a background thread via _try_connect) so its destructor doesn't
         # run during shutdown.
@@ -362,7 +364,12 @@ class LSLInletProducer(BaseStatefulProducer[LSLInletSettings, typing.Optional[Ax
         if self._state.inlet is None:
             return None
 
-        result = self._pull()
+        if not getattr(self, "_warmed_up", False):
+            result = await asyncio.to_thread(self._pull, 1.0)
+            if result is not None:
+                self._warmed_up = True
+            return result
+        result = self._pull()  # steady state: inline, non-blocking (timeout=0.0)
         if result is None:
             await asyncio.sleep(0.001)
         return result

--- a/src/ezmsg/lsl/inlet.py
+++ b/src/ezmsg/lsl/inlet.py
@@ -297,18 +297,26 @@ class LSLInletProducer(BaseStatefulProducer[LSLInletSettings, typing.Optional[Ax
             key=inlet_info.name(),
         )
 
-    def _pull(self) -> typing.Optional[AxisArray]:
-        """Pull available data from the inlet. Non-blocking (timeout=0.0)."""
+    def _pull(self, timeout: float = 0.0) -> typing.Optional[AxisArray]:
+        """Pull available data from the inlet.
+
+        ``timeout`` is the liblsl pull_chunk timeout (max wait for the first
+        sample). Run via ``asyncio.to_thread`` with a small non-zero timeout so
+        the liblsl C call (which releases the GIL) executes on a worker thread,
+        keeping the event-loop thread free to service co-located units (e.g. an
+        outlet) — the first-data ``proc_ALL`` warmup otherwise stalls the loop.
+        """
         if self._state.inlet is None:
             return None
         try:
             if self._state.fetch_buffer is not None:
                 samples, timestamps = self._state.inlet.pull_chunk(
+                    timeout=timeout,
                     max_samples=self._state.fetch_buffer.shape[0],
                     dest_obj=self._state.fetch_buffer,
                 )
             else:
-                samples, timestamps = self._state.inlet.pull_chunk()
+                samples, timestamps = self._state.inlet.pull_chunk(timeout=timeout)
                 samples = np.array(samples)
         except Exception:
             # Stream may have been closed concurrently by shutdown.


### PR DESCRIPTION
First data triggers liblsl's proc_ALL warmup (dejitter/monotonize/ clocksync init) which can occupy the event-loop thread for tens of ms and stall a co-located outlet. Run pulls on a worker thread (liblsl releases the GIL via ctypes) UNTIL the first data arrives — absorbing the warmup off the loop — then pull inline (non-blocking) so steady state has zero per-pull thread-hop overhead regardless of stream rate.